### PR TITLE
[ode16_adaptation] In ode 16 the used methods have been moved

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -30,5 +30,5 @@
   <author>Sascha Arnold/sascha.arnold@dfki.de</author>
   <depend package="base/cmake" />
   <depend package="envire/envire_core" />
-  <depend package="simulation/ode" />
+  <depend package="simulation/ode-16" />
 </package>

--- a/test/test_collision.cpp
+++ b/test/test_collision.cpp
@@ -26,7 +26,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <iostream>
-#include <ode/collision.h>
+#include <ode/odeinit.h>
 #include <envire_core/items/Item.hpp>
 #include <envire_collision/Exceptions.hpp>
 


### PR DESCRIPTION
This change breaks compatibility withe older versions of ODE. One of them is the one that mars currently uses by default.